### PR TITLE
Verwijder `dpl.core.foreign_operation.span_id` 

### DIFF
--- a/media/openapi.yml
+++ b/media/openapi.yml
@@ -132,13 +132,6 @@ components:
               type: string
               description: Type van de identificerende code, zoals BSN, personeelsnummer, of een URI naar een Register dat het type specificeert
               example: BSN
-            dpl.core.foreign_operation.span_id:
-              type: string
-              description: Unieke identificerende code van de Actie bij externe partij
-              example: beb0291b5162d850
-              externalDocs:
-                description: Definitie van Actie in de standaard logboek dataverwerkingen
-                url: https://logius-standaarden.github.io/logboek-dataverwerkingen/#dfn-acties
             dpl.core.foreign_operation.processor:
               type: string
               format: uri


### PR DESCRIPTION
Deze informatie is niet beschikbaar bij de vragende service. De bevraagde service genereert random een spanId, deze wordt niet weer terug gecommuniceerd aan de vragende service.

`dpl.core.foreign_operation.span_id` is ook niet nodig bij het weergeven van een trace. Zodra de vragende service kan aangeven welke services zijn bevraagd (via dpl.core.foreign_operation.processor) kan de bevraagde service aangeroepen worden met het `traceId`. In de response hiervan is een `parentSpanId` welke overeenkomt met een `spanId` van de logs van de vragende service. 