### PR TITLE
Make description of attributes property more clear. 

### DIFF
--- a/media/openapi.yml
+++ b/media/openapi.yml
@@ -144,6 +144,7 @@ components:
             - dpl.core.processing_activity_id
             - dpl.core.data_subject_id
             - dpl.core.data_subject_id_type
+          additionalProperties: true  
       required:
         - traceId
         - spanId

--- a/media/openapi.yml
+++ b/media/openapi.yml
@@ -111,7 +111,7 @@ components:
             url: https://www.hci-itil.com/ITIL_v3/books/3_service_transition/service_transition_ch4_3.html    
         attributes:
           type: object
-          description: Het veld attributes is een object, opgebouwd uit velden in een namespace met prefix dpl (data processing log). De eerste drie velden zijn vereist in de namespace core de laatste twee zijn enkel vereist als er een aanroepende Applicatie is
+          description: Het veld attributes is een object, opgebouwd uit de volgende vier velden in een namespace met prefix dpl (data processing log). De eerste drie velden zijn vereist in de namespace core, het laatste veld is enkel vereist als er een aanroepende Applicatie is
           properties:
             dpl.core.processing_activity_id:
               type: string
@@ -144,7 +144,6 @@ components:
             - dpl.core.processing_activity_id
             - dpl.core.data_subject_id
             - dpl.core.data_subject_id_type
-          additionalProperties: true  
       required:
         - traceId
         - spanId


### PR DESCRIPTION
Vanuit de spec file: 
```
Het veld attributes is een object, opgebouwd uit velden in een namespace met prefix dpl (data processing log). 
```

Stel, er zijn ook andere attributen met een dpl. prefix, willen we dan dat deze ook terug gegeven worden? Of willen we enkel de in de spec-file genoemde prefixes terug geven? 

Deze PR is alleen nog als we ook andere attributen willen terug geven, sluit gerust de PR als het antwoord nee is. 


